### PR TITLE
Fix: "undefined" 클래스명 문제 해결을 위해 classnames 라이브러리 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "axios": "^1.6.7",
     "axios-retry": "^4.0.0",
     "chart.js": "^4.4.1",
+    "classnames": "^2.5.1",
     "date-fns": "^3.3.1",
     "he": "^1.2.0",
     "react": "^18.2.0",

--- a/src/components/BottomBar/BottomBar.tsx
+++ b/src/components/BottomBar/BottomBar.tsx
@@ -1,20 +1,19 @@
+import classNames from "classnames";
 import { ReactElement } from "react";
 import "./BottomBar.css";
 
 type Props = {
   className?: string;
   children: ReactElement;
-  isSlideUp?: boolean | "";
+  isSlideUp?: boolean;
 };
 
-export const BottomBar = ({
-  children,
-  className = "",
-  isSlideUp = "",
-}: Props) => {
+export const BottomBar = ({ children, className, isSlideUp }: Props) => {
   return (
     <footer
-      className={`bottom-bar ${className} ${isSlideUp && "animate-slide-up md:animate-none"}`}
+      className={classNames("bottom-bar", className, {
+        "animate-slide-up md:animate-none": isSlideUp,
+      })}
     >
       {children}
     </footer>

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { ButtonHTMLAttributes } from "react";
 
 export type ButtonVariant = "filled" | "outlined";
@@ -31,7 +32,11 @@ export const Button = ({
 }: ButtonProps) => {
   return (
     <button
-      className={`rounded-lg border px-6 py-3 text-lg font-semibold shadow transition disabled:cursor-not-allowed disabled:opacity-70 ${BUTTON_STYLES[variant][color]} ${className} `}
+      className={classNames(
+        "rounded-lg border px-6 py-3 text-lg font-semibold shadow transition disabled:cursor-not-allowed disabled:opacity-70",
+        BUTTON_STYLES[variant][color],
+        className
+      )}
       type={type}
       {...props}
     >

--- a/src/components/EmptyView.tsx
+++ b/src/components/EmptyView.tsx
@@ -5,7 +5,7 @@ type Props = { title?: string };
 
 export const EmptyView = ({ title = "페이지가 존재하지 않습니다." }: Props) => {
   return (
-    <div className={"flex items-center justify-center p-MAIN_PADDING_X"}>
+    <div className="flex items-center justify-center p-MAIN_PADDING_X">
       <div className="flex w-full max-w-MAX_MAIN_WIDTH flex-col gap-8 text-center">
         <div>
           <div className="text-[12em]">😦</div>

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { ReactNode } from "react";
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
@@ -28,7 +29,7 @@ export const Heading = ({
 
   return (
     <Tag
-      className={`break-keep ${HEADING_STYLES[size]} ${className}`}
+      className={classNames("break-keep", HEADING_STYLES[size], className)}
       {...props}
     >
       {children}

--- a/src/components/QuizCards/QuizCard/QuizProgress.tsx
+++ b/src/components/QuizCards/QuizCard/QuizProgress.tsx
@@ -1,5 +1,6 @@
 import { Heading } from "@components/Heading";
 import { useQuizStore } from "@store/quizStore";
+import classNames from "classnames";
 
 const determineProgressIndicatorColor = (
   userAnswer: string,
@@ -42,7 +43,14 @@ export const QuizProgress = () => {
             <li
               key={correctAnswer}
               aria-current={isCurrent}
-              className={`h-1 ${determineProgressIndicatorColor(userAnswer, correctAnswer, isCurrent)}`}
+              className={classNames(
+                "h-1",
+                determineProgressIndicatorColor(
+                  userAnswer,
+                  correctAnswer,
+                  isCurrent
+                )
+              )}
               style={{
                 width: `${(1 / total) * 100}%`,
               }}

--- a/src/components/QuizCards/QuizCard/ResultText.tsx
+++ b/src/components/QuizCards/QuizCard/ResultText.tsx
@@ -1,3 +1,5 @@
+import classNames from "classnames";
+
 type Props = {
   isCorrect: boolean;
   correctText: string;
@@ -11,7 +13,10 @@ export const ResultText = ({
 }: Props) => {
   return (
     <span
-      className={`text-2xl font-bold ${isCorrect ? "text-green" : "text-red"}`}
+      className={classNames(
+        "text-2xl font-bold",
+        isCorrect ? "text-green" : "text-red"
+      )}
     >
       {isCorrect ? correctText : incorrectText}
     </span>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import he from "he";
 
 type Props = {
@@ -6,5 +7,5 @@ type Props = {
 };
 
 export const Text = ({ children, className }: Props) => {
-  return <span className={className}>{he.decode(children)}</span>;
+  return <span className={classNames(className)}>{he.decode(children)}</span>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,6 +3383,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-css@^5.2.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"


### PR DESCRIPTION
컴포넌트의 `className` prop이 `undefined`일 때 "undefined" 문자열이 추가되는 문제를 해결했습니다.

- `classnames` 라이브러리를 프로젝트 의존성에 추가하였습니다.
- 기존 컴포넌트에서 `className`을 직접 조작하여 사용하던 부분을 `classnames`를 사용하여 리팩토링하였습니다. 이를 통해 `className`이 `undefined`인 경우 해당 값이 클래스에 포함되지 않도록 처리하였습니다.

### 변경 전:
<img width="385" alt="image" src="https://github.com/JayeHa/quiz-app/assets/66169832/21a4e3cf-db9c-4ef7-a9f3-d5adebb3b15a">

### 변경 후:
<img width="315" alt="image" src="https://github.com/JayeHa/quiz-app/assets/66169832/ac9be8c6-d682-4f52-93b9-e8de902363bd">
